### PR TITLE
Add SwiftUI frontend and Python backend for streaming Ollama chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# AI
+# AI Chat Application
+
+This project provides a macOS SwiftUI frontend and a Python backend to interact with an Ollama model. The UI displays the model's streaming output and separates the model's internal reasoning (between `<think>` tags) in an expandable section.
+
+## Backend (Python)
+
+The backend uses FastAPI and streams the output of the model via WebSocket.
+
+### Setup
+
+```bash
+cd backend
+pip install -r requirements.txt
+python server.py
+```
+
+The server starts on `http://localhost:8000` and exposes a WebSocket endpoint at `ws://localhost:8000/ws`.
+
+## Frontend (SwiftUI)
+
+The macOS app is located in `macos/AIChat`. It connects to the backend via WebSocket and renders the streamed Markdown response while showing the model's "thoughts" in a collapsible `DisclosureGroup`.
+
+### Building
+
+Open `macos/AIChat` in Xcode or build using Swift Package Manager:
+
+```bash
+cd macos/AIChat
+swift build
+```
+
+Run the resulting app. Enter a prompt and watch the streamed reply; expand **Thoughts** to inspect the model's reasoning.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,0 +1,69 @@
+import asyncio
+import json
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+import uvicorn
+
+MODEL = "goekdenizguelmez/JOSIEFIED-Qwen3:4b-q5_k_m"
+
+app = FastAPI()
+
+async def stream_ollama(prompt: str, ws: WebSocket):
+    """Run ollama and stream output to websocket, splitting thought and answer."""
+    process = await asyncio.create_subprocess_exec(
+        "ollama", "run", MODEL, prompt,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+
+    mode = "answer"
+    buffer = ""
+    try:
+        while True:
+            chunk = await process.stdout.read(64)
+            if not chunk:
+                break
+            text = chunk.decode("utf-8", errors="ignore")
+            buffer += text
+            while buffer:
+                if mode == "answer":
+                    idx = buffer.find("<think>")
+                    if idx != -1:
+                        pre = buffer[:idx]
+                        if pre:
+                            await ws.send_text(json.dumps({"type": "answer", "data": pre}))
+                        buffer = buffer[idx + len("<think>") :]
+                        mode = "thought"
+                    else:
+                        await ws.send_text(json.dumps({"type": "answer", "data": buffer}))
+                        buffer = ""
+                else:
+                    idx = buffer.find("</think>")
+                    if idx != -1:
+                        pre = buffer[:idx]
+                        if pre:
+                            await ws.send_text(json.dumps({"type": "thought", "data": pre}))
+                        buffer = buffer[idx + len("</think>") :]
+                        mode = "answer"
+                    else:
+                        await ws.send_text(json.dumps({"type": "thought", "data": buffer}))
+                        buffer = ""
+        await process.wait()
+    finally:
+        await ws.send_text(json.dumps({"type": "done"}))
+
+@app.websocket("/ws")
+async def websocket_endpoint(websocket: WebSocket):
+    await websocket.accept()
+    try:
+        data = await websocket.receive_text()
+        try:
+            payload = json.loads(data)
+            prompt = payload.get("prompt", "")
+        except json.JSONDecodeError:
+            prompt = data
+        await stream_ollama(prompt, websocket)
+    except WebSocketDisconnect:
+        pass
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/macos/AIChat/AIChatApp.swift
+++ b/macos/AIChat/AIChatApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct AIChatApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/macos/AIChat/ContentView.swift
+++ b/macos/AIChat/ContentView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+class ChatModel: ObservableObject {
+    @Published var thoughts: String = ""
+    @Published var response: String = ""
+    private var task: URLSessionWebSocketTask?
+
+    func send(prompt: String) {
+        thoughts = ""
+        response = ""
+        task?.cancel()
+        guard let url = URL(string: "ws://localhost:8000/ws") else { return }
+        task = URLSession.shared.webSocketTask(with: url)
+        task?.resume()
+        let payload = ["prompt": prompt]
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let text = String(data: data, encoding: .utf8) {
+            task?.send(.string(text)) { error in
+                if let error = error { print("Send error: \(error)") }
+            }
+        }
+        receive()
+    }
+
+    private func receive() {
+        task?.receive { [weak self] result in
+            switch result {
+            case .failure(let error):
+                print("Receive error: \(error)")
+            case .success(let message):
+                if case let .string(text) = message,
+                   let data = text.data(using: .utf8),
+                   let json = try? JSONSerialization.jsonObject(with: data) as? [String: String],
+                   let type = json["type"] {
+                    DispatchQueue.main.async {
+                        if type == "thought" {
+                            self?.thoughts += json["data"] ?? ""
+                        } else if type == "answer" {
+                            self?.response += json["data"] ?? ""
+                        } else if type == "done" {
+                            self?.task?.cancel()
+                            self?.task = nil
+                        }
+                    }
+                }
+                self?.receive()
+            }
+        }
+    }
+}
+
+struct ContentView: View {
+    @StateObject private var model = ChatModel()
+    @State private var prompt: String = ""
+    @State private var showThoughts: Bool = false
+
+    var body: some View {
+        VStack {
+            DisclosureGroup("Thoughts", isExpanded: $showThoughts) {
+                ScrollView {
+                    Text(model.thoughts)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(4)
+                }
+                .frame(height: 150)
+            }
+            .padding()
+
+            ScrollView {
+                if let attributed = try? AttributedString(markdown: model.response) {
+                    Text(attributed)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(4)
+                } else {
+                    Text(model.response)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(4)
+                }
+            }
+            .padding()
+
+            HStack {
+                TextEditor(text: $prompt)
+                    .frame(height: 80)
+                    .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color.gray))
+                Button("Send") {
+                    model.send(prompt: prompt)
+                }
+            }
+            .padding()
+        }
+        .frame(minWidth: 600, minHeight: 500)
+    }
+}

--- a/macos/AIChat/Package.swift
+++ b/macos/AIChat/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "AIChat",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "AIChat", targets: ["AIChat"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "AIChat",
+            path: "."
+        )
+    ]
+)


### PR DESCRIPTION
## Summary
- implement FastAPI backend that streams Ollama output via WebSocket and separates `<think>` content
- add SwiftUI macOS app that shows thoughts in a collapsible section and renders markdown live
- document setup and build steps in README

## Testing
- `python -m py_compile backend/server.py`
- `pip install -r backend/requirements.txt`
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6890c79611948323a9d968043bf2e49f